### PR TITLE
Remove disconnect function.  not needed

### DIFF
--- a/backend/persistent/datastores/bigquery.js
+++ b/backend/persistent/datastores/bigquery.js
@@ -33,10 +33,6 @@ export function connect(connection) {
     return Promise.resolve(client);
 }
 
-export function disconnect(connection) {
-    return pool.remove(connection);
-}
-
 /**
  * The following method will execute a query against the specified connection
  * @param {object} queryObject - The SQL to query against the connection


### PR DESCRIPTION
Remove the disconnect function from bigquery.js.  This was causing an issue when deleting a tab