### PR TITLE
Update the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ $ yarn run watch-headless
 Then, view the app in the electron window with:
 
 ```bash
-$ yarn run dev
+$ yarn run start-hot
 ```
 
 If you need to fully start over and rebuild the electron app, try:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ testing).
 ## Install
 
 ```sh
-$ git clone https://github.com/plotly/falcon-sql-client falcon-sql-client
+$ git clone https://github.com/plotly/falcon falcon
 $ cd falcon-sql-client
 $ yarn install
 ```


### PR DESCRIPTION
I noticed two details that were outdated in the contributing guide.

* The repo URL is for what I assume is an old name for the repo, the URL redirects here, so technically it works, but it would be less confusing if it was for the current URL.
* There is no `yarn run dev`, it was removed in 68553ed8375098067e0a02e45dc92cad2e09facc. It looks to me that the command to run now is `yarn run start-hot`.